### PR TITLE
handle other exceptions in the popup window

### DIFF
--- a/src/pyoncatqt/login.py
+++ b/src/pyoncatqt/login.py
@@ -138,6 +138,10 @@ class ONCatLoginDialog(QDialog):
             self.show_message("A username and/or password was not provided when logging in.")
             self.user_pwd.setText("")
             return
+        except Exception as e:  # noqa: BLE001
+            self.show_message(f"The following exception occured: {e}")
+            self.user_pwd.setText("")
+            return
 
         self.login_status.emit(True)
         # close dialog

--- a/tests/test_login_dialog.py
+++ b/tests/test_login_dialog.py
@@ -168,8 +168,8 @@ def test_login_dialog_no_password(qtbot: pytest.fixture) -> None:
     assert dialog.user_pwd.text() == ""
     assert dialog.button_login.isEnabled() is False
     qtbot.mouseClick(dialog.button_login, QtCore.Qt.LeftButton)
-    assert mock_agent.login.called_once_with(os.getlogin(), "")
-    assert dialog.show_message.called_once_with("A username and/or password was not provided when logging in.")
+    mock_agent.call_count == 0
+    assert dialog.show_message.call_count == 0
 
 
 def test_login_dialog_bad_password(qtbot: pytest.fixture) -> None:
@@ -183,8 +183,29 @@ def test_login_dialog_bad_password(qtbot: pytest.fixture) -> None:
     qtbot.wait(2000)
     assert dialog.user_pwd.text() == "bad_password"
     qtbot.mouseClick(dialog.button_login, QtCore.Qt.LeftButton)
-    assert mock_agent.login.called_once_with(os.getlogin(), "bad_password")
-    assert dialog.show_message.called_once_with("Invalid username or password. Please try again.")
+    mock_agent.login.assert_called_once_with(os.getlogin(), "bad_password")
+    dialog.show_message.assert_called_once_with("Invalid username or password. Please try again.")
+
+
+def test_login_dialog_other_exceptions(qtbot: pytest.fixture) -> None:
+    import urllib3
+
+    mock_agent = MagicMock(spec=pyoncat.ONCat)
+    mock_agent.login.side_effect = urllib3.exceptions.NameResolutionError
+    dialog = ONCatLoginDialog(agent=mock_agent)
+    dialog.show_message = MagicMock()
+    qtbot.addWidget(dialog)
+    dialog.show()
+    qtbot.keyClicks(dialog.user_pwd, "bad_password")
+    qtbot.wait(2000)
+    assert dialog.user_pwd.text() == "bad_password"
+    qtbot.mouseClick(dialog.button_login, QtCore.Qt.LeftButton)
+    mock_agent.login.assert_called_once_with(os.getlogin(), "bad_password")
+    # This is the error message that crashed Shiver when there is no internet connection
+    dialog.show_message.assert_called_once_with(
+        "The following exception occured: NameResolutionError.__init__() missing 3 \
+        required positional arguments: 'host', 'conn', and 'reason'"
+    )
 
 
 def test_login_dialog_no_agent(qtbot: pytest.fixture) -> None:

--- a/tests/test_login_dialog.py
+++ b/tests/test_login_dialog.py
@@ -203,8 +203,8 @@ def test_login_dialog_other_exceptions(qtbot: pytest.fixture) -> None:
     mock_agent.login.assert_called_once_with(os.getlogin(), "bad_password")
     # This is the error message that crashed Shiver when there is no internet connection
     dialog.show_message.assert_called_once_with(
-        "The following exception occured: NameResolutionError.__init__() missing 3 \
-        required positional arguments: 'host', 'conn', and 'reason'"
+        "The following exception occured: NameResolutionError.__init__() missing \
+3 required positional arguments: 'host', 'conn', and 'reason'"
     )
 
 


### PR DESCRIPTION
Shiver crashes user tries to login without internet connection. This exception was raised "llib3.exceptions.NameResolutionError" which is not handled. This pr adds a blanket exception handling to display the exception in the pop up window. 
EWM [9859](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=9859)
![image](https://github.com/user-attachments/assets/87a11a66-9ad5-4d27-b7aa-02da5171e3e1)

Fixed unit tests to correctly test difference use cases

# Short description of the changes:
<!-- Add a concise description here-->

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
