### PR TITLE
guard against timeout

### DIFF
--- a/src/pyoncatqt/login.py
+++ b/src/pyoncatqt/login.py
@@ -188,7 +188,13 @@ class ONCatLogin(QGroupBox):
     connection_updated = Signal(bool)
 
     def __init__(
-        self: QGroupBox, *, client_id: str = None, key: str = None, parent: QWidget = None, **kwargs: Dict[str, Any]
+        self: QGroupBox,
+        *,
+        client_id: str = None,
+        key: str = None,
+        parent: QWidget = None,
+        timeout: float = 10.0,
+        **kwargs: Dict[str, Any],
     ) -> None:
         """
         Initialize the ONCatLogin widget.
@@ -221,7 +227,7 @@ class ONCatLogin(QGroupBox):
         self.oncat_options_layout.addWidget(self.oncat_button, 4, 1)
 
         self.error_message_callback = None
-
+        self.timeout = timeout
         # OnCat agent
 
         self.oncat_url = get_data("login.oncat", "oncat_url")
@@ -245,6 +251,7 @@ class ONCatLogin(QGroupBox):
             token_getter=self.read_token,
             token_setter=self.write_token,
             flow=pyoncat.RESOURCE_OWNER_CREDENTIALS_FLOW,
+            timeout=self.timeout,
         )
 
         self.login_dialog = ONCatLoginDialog(agent=self.agent, parent=self, **kwargs)

--- a/tests/test_login_dialog.py
+++ b/tests/test_login_dialog.py
@@ -157,6 +157,41 @@ def test_login_dialog_nominal(qtbot: pytest.fixture) -> None:
     assert agent.login.called_once_with(os.getlogin(), "password")
 
 
+def test_login_dialog_timeout(qtbot: pytest.fixture) -> None:
+    import socket
+
+    mock_agent = MagicMock(spec=pyoncat.ONCat)
+    mock_agent.login.side_effect = socket.timeout
+    dialog = ONCatLoginDialog(agent=mock_agent)
+    mock_agent.timeout = 0.0000001
+    dialog.show_message = MagicMock()
+    qtbot.addWidget(dialog)
+    dialog.show()
+    qtbot.keyClicks(dialog.user_pwd, "password")
+    qtbot.wait(2000)
+    assert dialog.user_pwd.text() == "password"
+    qtbot.mouseClick(dialog.button_login, QtCore.Qt.LeftButton)
+    mock_agent.login.assert_called_once_with(os.getlogin(), "password")
+    dialog.show_message.assert_called_once_with("The following exception occured: ")
+
+
+def test_login_dialog_not_timeout(qtbot: pytest.fixture) -> None:
+    import socket
+
+    mock_agent = MagicMock(spec=pyoncat.ONCat)
+    mock_agent.login.side_effect = socket.timeout
+    dialog = ONCatLoginDialog(agent=mock_agent)
+    mock_agent.timeout = 10.0
+    dialog.show_message = MagicMock()
+    qtbot.addWidget(dialog)
+    dialog.show()
+    qtbot.keyClicks(dialog.user_pwd, "password")
+    qtbot.wait(2000)
+    assert dialog.user_pwd.text() == "password"
+    qtbot.mouseClick(dialog.button_login, QtCore.Qt.LeftButton)
+    mock_agent.call_count == 0
+
+
 def test_login_dialog_no_password(qtbot: pytest.fixture) -> None:
     mock_agent = MagicMock(spec=pyoncat.ONCat)
     mock_agent.login.side_effect = pyoncat.LoginRequiredError


### PR DESCRIPTION
# Short description of the changes:
<!-- Add a concise description here-->
This PR adds a 10s guard against possible timeout logins. 
Added unit tests as discussed.

EWM [9831](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=9831)
# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
